### PR TITLE
Added variables to shell script to simplify adoption.

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,12 @@
 rm package{,.bz2}
 dpkg-scanpackages -m debs /dev/null > package
 bzip2 package
-ncftpput -u USERNAME -p PASSWORD FTPADDRESS.COM /public_html/repo/ CydiaIcon.png
-ncftpput -u USERNAME -p PASSWORD FTPADDRESS.COM /public_html/repo/ Release
-ncftpput -u USERNAME -p PASSWORD FTPADDRESS.COM /public_html/repo/debs/ debs/*
-ncftpput -u USERNAME -p PASSWORD FTPADDRESS.COM /public_html/repo/ package.bz2
+
+USERNAME="Your Username"
+PASSWORD="Your Password"
+FTPADDRESS="Your FTP Address"
+
+ncftpput -u $USERNAME -p $PASSWORD $FTPADDRESS /public_html/repo/ CydiaIcon.png
+ncftpput -u $USERNAME -p $PASSWORD $FTPADDRESS /public_html/repo/ Release
+ncftpput -u $USERNAME -p $PASSWORD $FTPADDRESS /public_html/repo/debs/ debs/*
+ncftpput -u $USERNAME -p $PASSWORD $FTPADDRESS /public_html/repo/ package.bz2


### PR DESCRIPTION
Previously, someone intending to use the script had to replace each `USERNAME`, `PASSWORD`, and `FTPADDRESS.COM` with their own. By replacing their usage with variable evaluation, we more explicitly label the behavior in the script.
